### PR TITLE
Update AbstractTranslator.php

### DIFF
--- a/src/Carbon/AbstractTranslator.php
+++ b/src/Carbon/AbstractTranslator.php
@@ -317,7 +317,7 @@ abstract class AbstractTranslator extends Translation\Translator
             }
 
             return '_'.ucfirst($matches[1]);
-        }, strtolower($locale));
+        }, strtolower((string) $locale));
 
         $previousLocale = $this->getLocale();
 


### PR DESCRIPTION
strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/nesbot/carbon/src/Carbon/AbstractTranslator.php on line 320